### PR TITLE
build(dependabot): ignore minor and patch github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
           prefix: build
       directory: /
       ignore:
-          - dependency-name: "*"
+          - dependency-name: "actions/*"
             update-types:
                 ["version-update:semver-minor", "version-update:semver-patch"]
       schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
           include: scope
           prefix: build
       directory: /
+      ignore:
+          - dependency-name: "*"
+            update-types:
+                ["version-update:semver-minor", "version-update:semver-patch"]
       schedule:
           interval: monthly
       open-pull-requests-limit: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,15 @@ jobs:
         if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2.3.5
-            - uses: actions/setup-node@v2.4.1
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
               with:
                   node-version: 16
             - name: Get NPM Cache Directory
               id: npm-cache-dir
               run: |
                   echo "::set-output name=dir::$(npm config get cache)"
-            - uses: actions/cache@v2.1.6
+            - uses: actions/cache@v2
               id: npm-cache
               with:
                   path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -64,10 +64,10 @@ jobs:
             github.actor != 'dependabot[bot]'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2.3.5
+            - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-            - uses: wagoid/commitlint-github-action@v4.1.9
+            - uses: wagoid/commitlint-github-action@v4
               with:
                   configFile: ./package.json
 
@@ -76,15 +76,15 @@ jobs:
         if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2.3.5
-            - uses: actions/setup-node@v2.4.1
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
               with:
                   node-version: 16
             - name: Get NPM Cache Directory
               id: npm-cache-dir
               run: |
                   echo "::set-output name=dir::$(npm config get cache)"
-            - uses: actions/cache@v2.1.6
+            - uses: actions/cache@v2
               id: npm-cache
               with:
                   path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -104,12 +104,12 @@ jobs:
             github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2.3.5
+            - uses: actions/checkout@v2
             - name: Save PR Number
               run: |
                   mkdir -p ./pr
                   echo ${{ github.event.number }} > ./pr/NR
-            - uses: actions/upload-artifact@v2.2.4
+            - uses: actions/upload-artifact@v2
               with:
                   name: pr
                   path: pr/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v2.3.5
+              uses: actions/checkout@v2
             # Initialises the CodeQL tools for scanning
             - name: Initialise CodeQL
               uses: github/codeql-action/init@v1

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -32,8 +32,8 @@ jobs:
         if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2.3.5
-            - uses: actions/setup-node@v2.4.1
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
               with:
                   node-version: 16
             - name: Run Linkinator

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2.3.5
+            - uses: actions/checkout@v2
             - name: TypoCheck
               uses: typoci/spellcheck-action@v1.1.0
               env:


### PR DESCRIPTION
GitHub introduced the [ability to ignore specific updates](https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/) back in May.
This PR should stop Dependabot flooding PRs with every minor and patch update of GitHub's own actions every day.